### PR TITLE
Fix for result validation; Error in usage example

### DIFF
--- a/src/ibmq.jl
+++ b/src/ibmq.jl
@@ -66,15 +66,15 @@ end
 
 @option mutable struct JobInfo
     kind::String
-    backend::Dict{String, String}
+    backend::Dict{String,String}
     userId::String
     status::String
     id::String
     # optional
-    timePerStep::Maybe{Dict{String, String}} = nothing
+    timePerStep::Maybe{Dict{String,String}} = nothing
     name::Maybe{String} = nothing
-    share_level::Maybe{Int}=nothing
-    tags::Maybe{Vector{String}}=nothing
+    share_level::Maybe{Int} = nothing
+    tags::Maybe{Vector{String}} = nothing
     qobj::Maybe{Schema.Qobj} = nothing
     allowObjectStorage::Maybe{Bool} = nothing
     objectStorageInfo::Maybe{StorageInfo} = nothing
@@ -82,7 +82,7 @@ end
     runMode::Maybe{String} = nothing
     creationDate::Maybe{DateTime} = nothing
     endDate::Maybe{DateTime} = nothing
-    hubInfo::Maybe{Dict{String, Any}} = nothing
+    hubInfo::Maybe{Dict{String,Any}} = nothing
 end
 
 function update_job_info(info::JobInfo, new::AbstractDict)
@@ -108,9 +108,9 @@ end
 
 @option struct RemoteJob
     dev::String
-    name::Maybe{String}=nothing
-    share_level::Maybe{Int}=nothing
-    tags::Maybe{Vector{String}}=nothing
+    name::Maybe{String} = nothing
+    share_level::Maybe{Int} = nothing
+    tags::Maybe{Vector{String}} = nothing
 end
 
 function RemoteJob(dev::Schema.DeviceInfo, name, share_level, tags)
@@ -175,7 +175,7 @@ end
 
 Download the results of given `job`, return `nothing` if the job status is not `COMPLETED`.
 """
-function results(account::AccountInfo, job::JobInfo; use_object_storage::Bool = true)
+function results(account::AccountInfo, job::JobInfo; use_object_storage::Bool=true)
     response = status(account, job)
     response.status == "COMPLETED" || return
 
@@ -194,6 +194,7 @@ function results(account::AccountInfo, job::JobInfo; use_object_storage::Bool = 
                 rethrow(e)
             end
         end
+        println(result_response)
         return Configurations.from_dict_inner(Schema.Result, result_response)
     else
         response = retreive_job_info(job_api, account.access_token)

--- a/src/ibmq.jl
+++ b/src/ibmq.jl
@@ -194,7 +194,6 @@ function results(account::AccountInfo, job::JobInfo; use_object_storage::Bool=tr
                 rethrow(e)
             end
         end
-        println(result_response)
         return Configurations.from_dict_inner(Schema.Result, result_response)
     else
         response = retreive_job_info(job_api, account.access_token)

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -328,6 +328,7 @@ simulator data). See below.
     status::String
     success::Bool
     meas_level::Int
+    circ_id::Int
     time_taken::Float64
     seed_simulator::Maybe{Int} = nothing
     seed::Maybe{Int} = nothing

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -327,6 +327,7 @@ simulator data). See below.
     shots::Union{Int,Vector{Int}}
     status::String
     success::Bool
+    meas_level::Int
     time_taken::Float64
     seed_simulator::Maybe{Int} = nothing
     seed::Maybe{Int} = nothing
@@ -357,7 +358,6 @@ The results data structure from Job.result().
     date::DateTime
     status::String
     success::Bool
-    meas_level::Int
     results::Vector{ExpResult}
 end
 

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -24,24 +24,24 @@ end
     id::String
     username::String
     email::String
-    urls::Dict{String, Any}
-    userType::String="Standard"
+    urls::Dict{String,Any}
+    userType::String = "Standard"
     firstName::Maybe{String} = nothing
     lastName::Maybe{String} = nothing
     institution::Maybe{String} = nothing
     applications::Vector{String} = String[]
     subscriptions::Subscription = Subscription()
-    readOnly::Bool=false
-    needsRefill::Bool=false
-    iqxPreferences::Dict{String, Any} = Dict{String, Any}()
+    readOnly::Bool = false
+    needsRefill::Bool = false
+    iqxPreferences::Dict{String,Any} = Dict{String,Any}()
     loginAccounts::Vector{Any} = []
-    ibmQNetwork::Bool=true
+    ibmQNetwork::Bool = true
     qNetworkRoles::Vector{String} = []
     roles::Vector{Any} = []
-    emailVerified::Bool=false
-    terms::Dict{String, Any} = Dict{String, Any}()
-    canScheduleBackends::Bool=true
-    servicesRoles::Vector{String}=[]
+    emailVerified::Bool = false
+    terms::Dict{String,Any} = Dict{String,Any}()
+    canScheduleBackends::Bool = true
+    servicesRoles::Vector{String} = []
 end
 
 UserInfo(d::AbstractDict{String}) = from_dict(UserInfo, d)
@@ -139,7 +139,7 @@ the property is false and new tags can be added.
     configurable::Bool = false
     credits_required::Bool = false
     allow_q_object::Bool = false
-    allow_object_storage::Bool=false
+    allow_object_storage::Bool = false
     n_registers::Maybe{Int} = nothing
     open_pulse::Bool = false
     quantum_volume::Maybe{Int} = nothing
@@ -292,11 +292,11 @@ The types of snapshots offered are defined in a separate specification document
 for simulators.
 """
 @option struct ExpData <: IBMQSchema
-    counts::Dict{String, Int}
+    counts::Dict{String,Int}
     memory::Maybe{Vector{String}} = nothing
     statevector::Maybe{Matrix{ComplexF64}} = nothing
     unitary::Maybe{Matrix{ComplexF64}} = nothing
-    snapshots::Maybe{Dict{String, Any}} = nothing
+    snapshots::Maybe{Dict{String,Any}} = nothing
 end
 
 """
@@ -322,9 +322,9 @@ the type of experiment (`"QASM"` or `"PULSE"`) and/or the type of backend (e.g.
 simulator data). See below.
 """
 @option struct ExpResult <: IBMQSchema
-    metadata::Maybe{Dict{String, Any}} = nothing
-    header::Maybe{Dict{String, Any}} = nothing
-    shots::Union{Int, Vector{Int}}
+    metadata::Maybe{Dict{String,Any}} = nothing
+    header::Maybe{Dict{String,Any}} = nothing
+    shots::Union{Int,Vector{Int}}
     status::String
     success::Bool
     time_taken::Float64
@@ -347,8 +347,8 @@ The results data structure from Job.result().
 - `results`: List of `m` (number of experiments) exp result data structures (defined below).
 """
 @option struct Result <: IBMQSchema
-    header::Maybe{Dict{String, Any}} = nothing
-    metadata::Maybe{Dict{String, Any}} = nothing
+    header::Maybe{Dict{String,Any}} = nothing
+    metadata::Maybe{Dict{String,Any}} = nothing
     time_taken::Maybe{Float64} = nothing
     qobj_id::String
     job_id::String
@@ -357,6 +357,7 @@ The results data structure from Job.result().
     date::DateTime
     status::String
     success::Bool
+    meas_level::Int
     results::Vector{ExpResult}
 end
 
@@ -395,7 +396,7 @@ Abstract type for Qobj schema instructions.
 """
 abstract type Instruction <: IBMQSchema end
 
-Configurations.is_option(::Type{T}) where {T <: Instruction} = true
+Configurations.is_option(::Type{T}) where {T<:Instruction} = true
 
 """
     struct BooleanFunction <: Instruction
@@ -517,7 +518,7 @@ experiment. These will override the configuration settings of the whole job. See
 - `instructions`: List of sequence commands that define the experiment. See [`Instruction`](@ref).
 """
 @option struct Experiment <: IBMQSchema
-    header::Maybe{Dict{String, Any}} = nothing
+    header::Maybe{Dict{String,Any}} = nothing
     # NOTE: the schema specification didn't mention
     # but this can be optional
     config::Maybe{ExpConfig} = nothing
@@ -548,10 +549,10 @@ the backend that the experiments were compiled for.
     type::String = "QASM"
     schema_version::VersionNumber = v"1.3"
     experiments::Vector{Experiment} = Experiment[]
-    header::Maybe{Dict{String, Any}} = nothing
+    header::Maybe{Dict{String,Any}} = nothing
     config::ExpConfig
 end
 
-Configurations.to_dict(::Type{T}, x::VersionNumber) where {T <: IBMQSchema} = string(x)
+Configurations.to_dict(::Type{T}, x::VersionNumber) where {T<:IBMQSchema} = string(x)
 
 end


### PR DESCRIPTION
When running the usage example from the docs, there is an error when downloading the result.

Fixed it by adding meas_level and curc_id keys to the ExpResult schema.